### PR TITLE
fix: restore the SSA inventory applier vk-sandbox consumes

### DIFF
--- a/pkg/scale/sandboxstore_impl.go
+++ b/pkg/scale/sandboxstore_impl.go
@@ -623,6 +623,36 @@ func (p *NodeInventoryPublisher) Publish(ctx context.Context) (int, error) {
 	return len(entries), nil
 }
 
+var _ InventoryApplier = (*ssaInventoryApplier)(nil)
+
+type ssaInventoryApplier struct {
+	c          client.Client
+	fieldOwner string
+}
+
+// NewSSAInventoryApplier returns the default server-side-apply InventoryApplier.
+func NewSSAInventoryApplier(c client.Client, fieldOwner string) InventoryApplier {
+	if fieldOwner == "" {
+		fieldOwner = "cocoon-node-inventory-publisher"
+	}
+	return &ssaInventoryApplier{c: c, fieldOwner: fieldOwner}
+}
+
+func (a *ssaInventoryApplier) Apply(ctx context.Context, inv *NodeInventory) error {
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(inv)
+	if err != nil {
+		return fmt.Errorf("scale: encode node inventory: %w", err)
+	}
+	u := &unstructured.Unstructured{Object: raw}
+	u.SetGroupVersionKind(NodeInventoryGVK)
+	u.SetName(inv.Node)
+	ac := client.ApplyConfigurationFromUnstructured(u)
+	if err := a.c.Apply(ctx, ac, client.FieldOwner(a.fieldOwner), client.ForceOwnership); err != nil {
+		return fmt.Errorf("scale: server-side-apply node inventory: %w", err)
+	}
+	return nil
+}
+
 var (
 	_ InventorySource  = (*StaticInventorySource)(nil)
 	_ InventoryApplier = (*StaticInventorySource)(nil)

--- a/pkg/scale/sandboxstore_impl_test.go
+++ b/pkg/scale/sandboxstore_impl_test.go
@@ -12,8 +12,11 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	sandboxv1beta1 "github.com/cocoonstack/sandbox-operator/api/v1beta1"
+	extv1beta1 "github.com/cocoonstack/sandbox-operator/extensions/api/v1beta1"
 )
 
 func TestScatterGatherList_FlattensAllNodes(t *testing.T) {
@@ -269,6 +272,30 @@ func TestWatchSeesAShortLivedSandbox(t *testing.T) {
 			t.Fatal("a short-lived sandbox produced no event")
 		}
 	}
+}
+
+func TestSSAApplier_UpsertsOneObjectPerNode(t *testing.T) {
+	ctx := t.Context()
+	cli := fake.NewClientBuilder().WithScheme(newScaleScheme(t)).Build()
+	pub := NewNodeInventoryPublisher("n1", sliceLive{entry("ns/a", "Running")},
+		NewSSAInventoryApplier(cli, "vk-test"), logr.Discard())
+
+	_, err := pub.Publish(ctx)
+	require.NoError(t, err)
+
+	got := &extv1beta1.NodeInventory{}
+	require.NoError(t, cli.Get(ctx, client.ObjectKey{Name: "n1"}, got))
+	require.Len(t, got.Entries, 1)
+
+	pub = NewNodeInventoryPublisher("n1", sliceLive{entry("ns/a", "Running"), entry("ns/b", "Running")},
+		NewSSAInventoryApplier(cli, "vk-test"), logr.Discard())
+	_, err = pub.Publish(ctx)
+	require.NoError(t, err)
+
+	list := &extv1beta1.NodeInventoryList{}
+	require.NoError(t, cli.List(ctx, list))
+	require.Len(t, list.Items, 1)
+	assert.Len(t, list.Items[0].Entries, 2)
 }
 
 func inv(node string, entries ...InventoryEntry) *NodeInventory {


### PR DESCRIPTION
`87e3263` cut `NewSSAInventoryApplier` as an unwired constructor. It is unwired *in this repo* — the consumer is [vk-sandbox](https://github.com/cocoonstack/vk-sandbox), whose `startInventoryPublisher` builds it to publish node inventory:

```go
pub := inventory.NewPublisher(o.nodeName,
    inventory.NewLiveSource(p, lister),
    inventory.NewNodeInfoSource(advertiseAddr, lister),
    scale.NewSSAInventoryApplier(cclient, "vk-sandbox"),   // <- deleted
    o.log.WithName("inventory"))
```

So vk-sandbox does not compile against sandbox-operator HEAD. It builds today only because its go.mod still pins `v0.0.0-20260726160753-0c71cfef8125`, which predates the cut.

`pkg/scale` publishes the whole node-side publisher toolkit — `NodeInventory`, `NodeInventoryGVK`, `InventoryApplier`, `NodeLiveSource`, `NewNodeInventoryPublisher` — and this was its only production applier; `StaticInventorySource` is the in-memory test double. Shipping the toolkit without the applier leaves every out-of-tree publisher hand-rolling SSA against the GVK, which is the drift the type exists to prevent.

Restored verbatim, minus the comment the `InventoryApplier` godoc already carries, plus `TestSSAApplier_UpsertsOneObjectPerNode`: publish through a client, assert the object lands under the node name, republish, assert one object carrying the new entries. Mutation-checked — corrupting the applied name fails the test.

Verified: `go build ./...`, `go test ./...`, `make lint` (0 issues on linux and darwin), `asl ./...` clean on both GOOS; `go build ./...` in vk-sandbox under the shared go.work passes again.

Follow-up once this lands: bump vk-sandbox's `sandbox-operator` pseudo-version so its pinned build and the workspace build agree.
