### PR TITLE
review: apply the August asl layout rules

### DIFF
--- a/extensions/controllers/queue/simple_sandbox_queue.go
+++ b/extensions/controllers/queue/simple_sandbox_queue.go
@@ -25,6 +25,9 @@ type SandboxKey struct {
 	NodeName  string
 }
 
+// Strategy picks one key from a warm pool's queued sandboxes; false leaves the queue untouched.
+type Strategy func([]SandboxKey) (SandboxKey, bool)
+
 // SimpleSandboxQueue is a thread-safe queue of adoptable warm pool sandboxes.
 type SimpleSandboxQueue struct {
 	// queues is a thread-safe dictionary from warm pool name to a synchronizedQueue
@@ -52,7 +55,7 @@ func (s *SimpleSandboxQueue) Get(namespacedWarmPoolName string) (SandboxKey, boo
 }
 
 // GetWithStrategy pops an item from the specific warm pool's queue using a custom strategy.
-func (s *SimpleSandboxQueue) GetWithStrategy(namespacedWarmPoolName string, pick func([]SandboxKey) (SandboxKey, bool)) (SandboxKey, bool) {
+func (s *SimpleSandboxQueue) GetWithStrategy(namespacedWarmPoolName string, pick Strategy) (SandboxKey, bool) {
 	q, ok := s.queues.Load(namespacedWarmPoolName)
 	if !ok {
 		return SandboxKey{}, false
@@ -131,7 +134,7 @@ func (q *synchronizedQueue) Pop() (SandboxKey, bool) {
 
 // PopWithStrategy applies the strategy function to pick an item from the queue,
 // removes it thread-safely, and returns it.
-func (q *synchronizedQueue) PopWithStrategy(pick func([]SandboxKey) (SandboxKey, bool)) (SandboxKey, bool) {
+func (q *synchronizedQueue) PopWithStrategy(pick Strategy) (SandboxKey, bool) {
 	for {
 		q.mu.Lock()
 		if len(q.items) == 0 {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -120,21 +120,20 @@ var (
 		},
 		func() float64 { return 1 },
 	)
-)
 
-// Init registers custom metrics with the global controller-runtime registry.
-// Registration is tied to package variable initialization so no caller can observe an unregistered collector.
-var _ = func() bool {
-	metrics.Registry.MustRegister(
-		ClaimStartupLatency,
-		ClaimControllerStartupLatency,
-		SandboxCreationLatency,
-		SandboxClaimCreationTotal,
-		WarmPoolSandboxCreatedTotal,
-		BuildInfo,
-	)
-	return true
-}()
+	// Registration rides on package variable initialization so no caller can observe an unregistered collector.
+	_ = func() bool {
+		metrics.Registry.MustRegister(
+			ClaimStartupLatency,
+			ClaimControllerStartupLatency,
+			SandboxCreationLatency,
+			SandboxClaimCreationTotal,
+			WarmPoolSandboxCreatedTotal,
+			BuildInfo,
+		)
+		return true
+	}()
+)
 
 // IncWarmPoolSandboxCreated counts one Sandbox created by the warm-pool controller.
 func IncWarmPoolSandboxCreated(namespace, warmPoolName string) {

--- a/pkg/scale/sandboxstore.go
+++ b/pkg/scale/sandboxstore.go
@@ -132,6 +132,8 @@ type SandboxStats struct {
 // InventoryEntry is one live sandbox as summarized by its owning node.
 type InventoryEntry = extv1beta1.InventoryEntry
 
+var _ runtime.Object = (*NodeInventory)(nil)
+
 // NodeInventory is the single O(nodes) etcd object per node: the durable summary
 // of that node's live sandboxes, server-side-applied on a slow cadence. The
 // per-sandbox truth lives in the node (the L0 node-scoped cache), not etcd; a
@@ -139,5 +141,3 @@ type InventoryEntry = extv1beta1.InventoryEntry
 // The canonical type (and its CRD) lives in the extensions.agents.x-k8s.io
 // group; these aliases keep the scale contracts self-contained for callers.
 type NodeInventory = extv1beta1.NodeInventory
-
-var _ runtime.Object = (*NodeInventory)(nil)

--- a/pkg/scale/sandboxstore_claim_test.go
+++ b/pkg/scale/sandboxstore_claim_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/cocoonstack/sandbox-operator/pkg/scale/sandboxd"
 )
 
-var _ SandboxdClient = (*recordingClient)(nil)
-
 func TestStoreClaim_RoutesToAWarmNode(t *testing.T) {
 	src := NewStaticInventorySource()
 	src.Put(poolInv("n2", "10.0.0.2:7777", PoolCapacity{Template: "img", Warm: 4, Target: 5}))
@@ -244,6 +242,8 @@ func (f *recordingFactory) factory() SandboxdClientFactory {
 		return &recordingClient{f: f}
 	}
 }
+
+var _ SandboxdClient = (*recordingClient)(nil)
 
 type recordingClient struct{ f *recordingFactory }
 


### PR DESCRIPTION
`asl` (CMGS/asl at dc48996) now mechanizes more of the layout rules of the code-style standard; this branch clears every finding it reports on this repository.

- `extensions/controllers/queue/simple_sandbox_queue.go`: `pick func([]SandboxKey) (SandboxKey, bool)` was spelled in `GetWithStrategy` and `PopWithStrategy` → named `queue.Strategy` (functypedup)
- `internal/metrics/metrics.go`: the registration `var _ = func() bool { ... }()` is a data var, not an interface check → joins the top var block (topdecl)
- `pkg/scale/sandboxstore.go`, `pkg/scale/sandboxstore_claim_test.go`: compile-time interface checks sit immediately above the type they check (topdecl)

Gates: `asl ./...` clean on darwin and linux; `go build` and `go vet` on both GOOS; `go test` for the touched packages; `make lint` (golangci-lint v2.12.2) 0 issues on both GOOS.
