### PR TITLE
docs: align compatibility and scaling status

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,17 +9,20 @@ move any of these forward are welcome.
   warm pools by engine; surface the axis through
   `SandboxTemplate`/`SandboxWarmPool` and the warm-pool driver so a single
   node can run mixed-engine pools under operator control.
-- **Prompt release for L3 claims.** Deleting a synthesized `Sandbox` should
-  release the node-local claim immediately via its `claim_ref` instead of
-  waiting for the claim TTL to reap it.
+- **Read-after-write routing for L3 claims.** Single-sandbox lookups already
+  avoid materializing the cluster-wide list, but a new claim is invisible until
+  its node republishes `NodeInventory`, and a miss still scans every inventory
+  entry. Keep a bounded claim-time owner index and fall back to authoritative
+  node lookup so lifecycle calls work immediately and lookup is `O(1)`.
 - **Engine-labeled pool metrics.** `sandboxd_pool_*` series currently collapse
   pools that share template/net/size but differ in engine.
 
 ## Medium term
 
-- **L2 ClaimGateway hardening.** Inline `SubjectAccessReview` +
-  `ResourceQuota` on the node-local claim path, promoting the benchmarked
-  skeleton to a supported deployment mode.
+- **L2 ClaimGateway deployment and quota hardening.** Package the concrete
+  gateway and orphan reconciler as a supported node-local deployment, wire its
+  existing `SubjectAccessReview` authorizer, and add `ResourceQuota` enforcement
+  on the claim path.
 - **Aggregated-apiserver HA.** Multi-replica scatter-gather with consistent
   claim routing (today: multiple replicas serve reads; claims prefer a single
   writer).

--- a/docs/e2b-compat.md
+++ b/docs/e2b-compat.md
@@ -9,7 +9,8 @@ It is a translation layer, not a second control plane. Every request lands on
 the same `SandboxStore` the Kubernetes API uses, so an e2b create *is* the
 node-local claim a `kubectl create sandbox` performs — and the sandbox it
 returns shows up in `kubectl get sandboxes`. Nothing extra is stored: sandbox
-identity is the sandboxd claim id the owning node already assigns.
+identity is a DNS-safe rendering of the sandboxd claim id the owning node
+already assigns; requests accept either spelling.
 
 ## Enable it
 
@@ -53,27 +54,44 @@ const sandbox = await Sandbox.create('registry.example.com/rt:24.04')
 
 | e2b endpoint | Maps to | Notes |
 |---|---|---|
-| `POST /sandboxes` | `store.Claim` | `templateID` → pool template; `timeout` → the claim's TTL; `allow_internet_access` → `egress` lane, else the hardened `none` lane. `201` on success, `503` when the pool is drained (retryable). |
+| `POST /sandboxes` | `store.Claim` | `templateID` → pool template; `timeout` → the claim's TTL (15s when omitted); `allow_internet_access` → `egress` lane, else the hardened `none` lane. `201` on success, `503` when the pool is drained (retryable). |
 | `GET /sandboxes`, `GET /v2/sandboxes` | `store.List` | Live sandboxes in the compat namespace. |
 | `GET /sandboxes/{id}` | `store.List` + id match | `404` when no live sandbox carries the id. |
 | `DELETE /sandboxes/{id}` | `store.Release` | Releases the node-local claim id, never by Kubernetes name. `204`. |
 | `POST /sandboxes/{id}/timeout` | existence check | TTL is fixed by the node at claim time; the call is verified and acknowledged, not silently faked. |
-| `POST /sandboxes/{id}/refreshes` | existence check | Keepalive; liveness is node-owned. |
+| `POST /sandboxes/{id}/refreshes` | existence check | Verifies that the sandbox is still live; it does not extend or refresh the node-owned deadline. |
+| `POST /sandboxes/{id}/pause` | `store.Pause` | Hibernates the owning node's claim. Omitted or `memory: true` snapshots memory; `memory: false` asks for an unsupported filesystem-only pause and returns `400`. Returns `409` when already paused. |
+| `POST /sandboxes/{id}/connect` | `store.Resume` when paused | The SDK's resume operation. Returns `200` when already running or `201` after restoring a paused sandbox. Its `timeout` field does not change the node-owned lease. |
+| `POST /sandboxes/{id}/fork` | `store.Fork` | Creates `count` children (`1` by default), each with its own id and requested claim-time TTL. A paused source returns `409`; resume it first. |
+| `POST /sandboxes/{id}/snapshots` | `store.Snapshot` | Captures a checkpoint while the source keeps running; returns its `snapshotID`. |
+| `GET /snapshots` | `store.Snapshots` across nodes | Lists fleet checkpoints. One unreachable node is skipped rather than blanking the whole result. |
+| `DELETE /templates/{snapshotID}` | `store.DeleteSnapshot` across nodes | e2b addresses snapshot deletion through the templates path; deletion is idempotent and best-effort across nodes. |
+| `GET /templates`, `GET /v2/templates` | advertised warm-pool keys | Lists the distinct templates the fleet can currently claim; these are pool-derived entries, not e2b-hosted template builds. |
+| `GET /sandboxes/{id}/metrics` | `store.Stats` | Returns the complete e2b metric schema; see the zero-valued fields below. |
 | `GET /health` | — | Unauthenticated, for probes. |
 
 ## Limits worth knowing
 
 - **Reaching `envd` (the in-sandbox data plane).** The SDK derives the sandbox
-  host as `{port}-{sandboxID}.{domain}`. A cocoon `sandboxID` is the sandboxd
-  claim id, which is not a valid DNS label, so that subdomain form only works
-  behind a proxy routing on the `E2b-Sandbox-Id` / `E2b-Sandbox-Port` headers
-  the SDK also sends. Otherwise set `E2B_SANDBOX_URL` explicitly.
+  host as `{port}-{sandboxID}.{domain}`. The compatibility API renders the
+  sandboxd claim id as a DNS-safe public id, but the deployment still needs
+  wildcard DNS/TLS and a proxy that routes the derived host or the
+  `E2b-Sandbox-Id` / `E2b-Sandbox-Port` headers the SDK sends. Otherwise set
+  `E2B_SANDBOX_URL` explicitly.
 - **`envdVersion`** is reported as `0.4.0` by default. The SDK version-compares
   it and *kills the sandbox* if it cannot parse it, so it is always sent.
-- **Not implemented:** pause/resume, fork, snapshots, templates, metrics, and
-  team/node admin endpoints. `pause`/`fork` map onto cocoon capabilities and are
-  the natural next step; the rest are e2b-hosted concerns.
+- **Metrics are schema-complete, not measurement-complete.** `cpuCount`,
+  `memUsed`, and `memTotal` come from the owning node when available;
+  `cpuUsedPct`, `memCache`, `diskUsed`, and `diskTotal` are reported as zero.
+- **List/detail schema fields are compatibility values.** `startedAt` uses the
+  synthesized Sandbox creation time; `endAt` is `startedAt + 15s`, not the
+  owning node's authoritative deadline. `cpuCount`, `memoryMB`, and
+  `diskSizeMB` are reported as zero on these responses.
 - **Size class** is pinned (`small`) — e2b's `NewSandbox` carries no size
   selector.
-- `metadata` and `envVars` are accepted so SDK calls do not fail, but the
-  node-local claim path takes neither today.
+- `metadata`, `envVars`, `autoPause`, and `secure` are accepted so SDK calls do
+  not fail, but are discarded: the node-local claim path takes none of them and
+  the compatibility layer stores no per-sandbox copy.
+- **Not implemented:** team/node administration and e2b-hosted template
+  build/management endpoints. Template listing is the pool-derived surface
+  above; snapshots use the implemented checkpoint lifecycle.

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,8 +75,8 @@ node, behind CRDs, RBAC and watch. Four layers:
 |---|---|---|
 | **L0** — API hygiene | cache-fed reads, diff-before-write, no control-loop `LIST` against etcd; the qualifier that stops APF seat exhaustion at scale | shipped |
 | **L1** — ownership transfer | claim = one select + one `PATCH`; `O(nodes)` pool status; per-pool sharded operator with a `coordination.k8s.io` Lease | implemented here |
-| **L2** — node-local claim gateway | a DaemonSet fronts `sandboxd`, delivers a running microVM in 0.2–0.7 ms, records `Bound` asynchronously; authorization stays central | designed, `ClaimGateway` skeleton |
-| **L3** — aggregated apiserver | `sandboxes` served by scatter-gathering per-node `NodeInventory`; etcd stores intent only, so object count drops from `O(sandboxes)` to `O(pools + nodes)` | designed, `SandboxStore` skeleton |
+| **L2** — node-local claim gateway | the concrete gateway fronts `sandboxd`, delivers a running microVM in 0.2–0.7 ms, records `Bound` asynchronously; authorization stays central | core implemented and benchmarked; supported DaemonSet packaging/hardening remains roadmap work |
+| **L3** — aggregated apiserver | `sandboxes` served by scatter-gathering per-node `NodeInventory`; etcd stores intent only, so object count drops from `O(sandboxes)` to `O(pools + nodes)` | implemented by `sandbox-apiserver`, its deployment/APIService manifests, and the cache-fed store |
 
 The measured consequence: one `kubectl patch` taking a `SandboxWarmPool` from 0
 to **50 000** microVMs on 20 bare-metal nodes reaches full supply in **10–15 s**

--- a/docs/scaling-design.md
+++ b/docs/scaling-design.md
@@ -20,9 +20,11 @@ scatter-gathering live node state, with *zero* etcd storage). Our thesis:
 > transaction plane down to the node — behind CRDs, RBAC, and watch, so
 > `kubectl get sandboxes` never stops working.**
 
-We stage this as four layers. **L0 is shipped.** L1 is implemented in this repo.
-L2/L3 have full designs, Go interface skeletons, and migration paths here;
-their complete implementations are follow-up work.
+We stage this as four layers. L0 and L1 are shipped. L2 has a concrete,
+benchmarked gateway and orphan reconciler, but still needs deployment hardening
+before it is a supported mode. L3 is implemented by the aggregated-apiserver
+binary, manifests, scatter-gather store, and `NodeInventory` publisher. Its
+remaining routing follow-up is called out below.
 
 ```mermaid
 flowchart LR
@@ -32,10 +34,10 @@ flowchart LR
     subgraph L1["L1 — ownership transfer (this repo)"]
         L1a["claim = single PATCH<br/>O(nodes) pool status<br/>per-pool sharded operator"]
     end
-    subgraph L2["L2 — node-local claim gateway"]
-        L2a["DaemonSet → sandboxd<br/>sub-ms delivery<br/>async Bound record"]
+    subgraph L2["L2 — node-local claim gateway core"]
+        L2a["gateway → sandboxd<br/>sub-ms delivery<br/>async Bound record"]
     end
-    subgraph L3["L3 — aggregated apiserver"]
+    subgraph L3["L3 — aggregated apiserver (implemented)"]
         L3a["scatter-gather node inventory<br/>etcd stores intent only<br/>O(sandboxes)→O(pools+nodes)"]
     end
     L0 --> L1 --> L2 --> L3
@@ -99,21 +101,23 @@ the claim path needs the scheduler, kubelet bind, or image pull.
 | Stale informer picks an already-claimed Sandbox | PATCH precondition fails → next candidate | No |
 
 **Acceptance:** claim p50 stays near-constant from a 100-pool to a 2000+-pool
-(today it degrades 33 ms → 516 ms); the pod-exclusivity invariant (one Sandbox,
-at most one claim) holds under concurrent claims.
+(measured 0.644 ms → 0.646 ms); the pod-exclusivity invariant (one Sandbox, at
+most one claim) holds under concurrent claims.
 
-### L2 — node-local claim gateway (designed; `ClaimGateway` skeleton)
+### L2 — node-local claim gateway (implemented core; deployment hardening pending)
 
 L1 still round-trips the apiserver. L2 takes the claim off the central path
 entirely for the runtimes that have a node-local warm pool (`sandboxd`), while
 keeping the `SandboxClaim` object as the durable record.
 
-**Mechanism.** A `ClaimGateway` DaemonSet on each virtual-kubelet node fronts
-`sandboxd`. A claim request reaches the node gateway directly; `sandboxd` hands
-over an already-running microVM in **0.2–0.7 ms** and returns connection info
-immediately. The `SandboxClaim` is marked `Bound` **asynchronously** — the record
-follows the action, exactly as kubelet static Pods record to the apiserver after
-the container is already running.
+**Mechanism.** The implemented `ClaimGateway` is intended to run on each
+virtual-kubelet node in front of `sandboxd`. A claim request reaches the node
+gateway directly; `sandboxd` hands over an already-running microVM in
+**0.2–0.7 ms** and returns connection info immediately. The `SandboxClaim` is
+marked `Bound` **asynchronously** — the record follows the action, exactly as
+kubelet static Pods record to the apiserver after the container is already
+running. The repository contains the concrete gateway and orphan reconciler;
+packaging it as a supported DaemonSet remains roadmap work.
 
 **Authorization stays central.** The gateway runs a `SubjectAccessReview`
 before delivery; only ownership transfer moves to the node.
@@ -137,12 +141,12 @@ type ClaimGateway interface {
 | Scenario | Behavior | Breaks k8s semantics? |
 |---|---|---|
 | Gateway crashes after delivery, before recording `Bound` | Orphan binding → audit-only orphan GC + adopt reconciles the record (the VM is never destroyed on pod-level state — see the delete-authorization contract) | No — eventual consistency |
-| Node has no warm VM | Falls back to the L1 Kubernetes path (create a new Sandbox) | No |
+| Node has no warm VM | Returns the explicit fallback signal; a deployment must route that request through the L1 Kubernetes path | No |
 
 **Acceptance:** claim p50 sub-millisecond on the sandboxd tier; orphan-binding
 rate converges to 0 via GC; `kubectl get sandboxclaims` still shows every claim.
 
-### L3 — aggregated apiserver: etcd stores intent, not sandboxes (designed; `SandboxStore` skeleton)
+### L3 — aggregated apiserver: etcd stores intent, not sandboxes (implemented)
 
 A million `Sandbox` objects in etcd is a dead end (churn alone blows the ~8 GB
 keyspace). The Kubernetes-native fix is the aggregation layer: serve
@@ -156,18 +160,18 @@ Each virtual-kubelet node already knows its own VMs (L0 made that cache the
 source of truth), so the aggregated server assembles a `SandboxList` by fanning
 out to node inventories — the exact pattern `metrics.k8s.io` uses to serve
 `PodMetrics` with zero etcd storage. `kubectl get sandboxes`, RBAC, field
-selectors, and `watch` (implemented as a merge of per-node inventory streams)
-all keep working; users never see that storage decentralized.
+selectors, and `watch` (currently implemented by polling and diffing the
+cache-fed `NodeInventory` view) all keep working; users never see that storage
+decentralized.
 
 ```go
 // SandboxStore backs the aggregated apiserver for sandboxes.agents.x-k8s.io.
-// It holds NO per-sandbox etcd objects: List/Get/Watch scatter-gather live
-// node inventories, and Create/Delete translate to intent (warm-pool desired
-// replicas) plus a node-local RPC.
+// It holds NO per-sandbox etcd objects: List/Get/Watch use the cache-fed node
+// inventories, and Create/Delete claim or release through a node-local RPC.
 type SandboxStore interface {
     List(ctx context.Context, opts ListOptions) (*SandboxList, error)   // fan-out to node inventories
-    Get(ctx context.Context, ns, name string) (*Sandbox, error)         // route to owning node
-    Watch(ctx context.Context, opts ListOptions) (watch.Interface, error) // merge per-node streams
+    Get(ctx context.Context, ns, name string) (*Sandbox, error)         // fan-out; materialize only the match
+    Watch(ctx context.Context, opts ListOptions) (watch.Interface, error) // poll and diff inventory
 }
 
 // NodeInventory is the one O(nodes) etcd object per node: the durable
@@ -188,10 +192,11 @@ type NodeInventory struct {
 | Node partitioned from aggregated server | Its sandboxes briefly absent from `List` (eventual consistency, same as an informer lag) | No |
 | A node `inventory` object lost | Rebuilt from the node's own live state on next publish | No |
 | Aggregated server restart | Stateless; rebuilds from node fan-out | No |
-| Client needs strong read-after-write | Route `Get` to the owning node (authoritative), not the summary | No |
+| Client reads before the owning node republishes inventory | The sandbox is briefly absent; retry until the next publish. Direct authoritative routing is the remaining follow-up below. | No — the read surface is explicitly eventually consistent |
 
 **Acceptance:** 1M sandbox *intent* costs `O(nodes)` etcd objects; `kubectl get
-sandboxes` returns the fanned-out list; per-sandbox `Get` is authoritative.
+sandboxes` returns the fanned-out list; per-sandbox `Get` only materializes the
+matching entry. Strong read-after-write and `O(1)` lookup remain follow-up work.
 
 ### L3 routing: why node choice is sampled, not maximized
 
@@ -213,15 +218,14 @@ fleet view is `O(nodes × sandboxes)` — 40 ms at 200 nodes and 50k sandboxes �
 so a watch with nothing to report stretches its poll up to 8× the base interval
 and snaps back to it on the first observed change.
 
-### L3 follow-up: resolve a sandbox without the summary (TODO)
+### L3 remaining follow-up: read after write without published inventory
 
-The risk table above already names the fix — *route `Get` to the owning node
-(authoritative), not the summary* — but today nothing does. Every single-sandbox
-path resolves through the synthesized read view instead: `lifecycleREST.Create`
-(the `pause` / `resume` / `snapshot` / `fork` subresources) calls
-`SandboxStore.Get`, and the e2b surface's `lookup` calls `SandboxStore.List` and
-linear-scans it for one claim id. Both inherit the summary's two properties, and
-neither is acceptable at the scale L3 targets.
+Single-sandbox lookup no longer builds the cluster-wide `SandboxList`.
+`SandboxStore.Get` and the e2b claim-id resolver fan out across the cache-fed
+per-node inventories, cancel on the first match, and materialize only that
+entry. This removes the previous `O(total sandboxes)` `Sandbox` allocation, but
+two limitations remain: the lookup cannot see a claim until the owning node
+publishes it, and a miss still scans up to every inventory entry.
 
 **It is stale for one publish interval.** A sandbox is live on its node the
 moment `Claim` returns, but it does not appear in the read view until that node
@@ -231,12 +235,10 @@ lifecycle verb issued inside that window answers `404`. Callers work around it
 by polling until visible — which is what `examples/lifecycle` does — so
 "create, then immediately pause" costs half a minute of polling.
 
-**It is `O(total sandboxes)` per call.** `List` scatter-gathers every
-`NodeInventory` and materializes *every* sandbox into a `Sandbox` object before
-the caller filters for one. A materialized `Sandbox` measures 1392 B of Go heap
-(`ObjectMeta` + synthesized labels/annotations + a `Condition`), so one `pause`
-allocates ~139 MB at 100 k sandboxes and ~1.4 GB at 1 M — transient garbage, to
-find a single record. This is the binding constraint, not the staleness.
+**It is still `O(total inventory entries)` CPU on a miss.** The fast path avoids
+materializing unrelated `Sandbox` objects, but finding the owner without an
+index still compares entries across the fleet. That scan, rather than heap
+growth from full-list synthesis, is the remaining scale constraint.
 
 Both fall out of the same omission: `Claim` already returns the node and the
 claim id — the e2b create response even hands the node back to the client as
@@ -258,8 +260,8 @@ rejected:** `NodeInventory` carries one 105 B entry per live sandbox
 (measured), so a node holding 2500 of them is a 263 KB object. Re-applying that
 on a 2 s debounce costs 52.6 MB/s of large-object server-side-apply traffic
 across 400 nodes at 1 M sandboxes, against 3.5 MB/s for the current 30 s
-cadence — and it would still leave the `O(total sandboxes)` allocation in place,
-because `lookup` would go on listing everything.
+cadence — and it would still leave the `O(total inventory entries)` lookup in
+place.
 
 **Acceptance:** a lifecycle verb succeeds on a sandbox claimed milliseconds ago;
 resolving one sandbox allocates `O(1)`, not `O(total sandboxes)`; index memory

--- a/pkg/e2bcompat/server.go
+++ b/pkg/e2bcompat/server.go
@@ -6,17 +6,17 @@
 // the same scale.SandboxStore the aggregated apiserver uses, so an e2b Create is
 // the identical node-local claim a `kubectl create sandbox` performs, and the
 // sandbox it returns is visible to `kubectl get sandboxes`. Nothing is stored
-// here; sandbox identity is the sandboxd claim id the node already assigns.
+// here; public identity is a DNS-safe rendering of the node's sandboxd claim id.
 //
 // Mapping to the e2b contract (e2b-dev/E2B spec/openapi.yml):
 //
-//	POST   /sandboxes                     -> store.Claim   (templateID -> pool template)
-//	GET    /sandboxes, /v2/sandboxes      -> store.List
-//	GET    /sandboxes/{sandboxID}         -> store.List + id match
-//	DELETE /sandboxes/{sandboxID}         -> store.Release
-//	POST   /sandboxes/{sandboxID}/timeout -> accepted (TTL is set at claim time)
-//	POST   /sandboxes/{sandboxID}/refreshes -> accepted (keepalive)
-//	GET    /health                        -> liveness
+//	POST/GET/DELETE /sandboxes                 -> claim, list, get, release
+//	POST /sandboxes/{id}/pause|connect|fork    -> pause, resume, fork
+//	POST /sandboxes/{id}/snapshots             -> create checkpoint
+//	GET /snapshots, DELETE /templates/{id}     -> list or delete checkpoints
+//	GET /templates, /v2/templates              -> advertised warm-pool keys
+//	GET /sandboxes/{id}/metrics                -> node resource statistics
+//	POST timeout|refreshes, GET /health         -> existence or liveness checks
 package e2bcompat
 
 import (
@@ -62,9 +62,8 @@ type Options struct {
 	// makes the SDK fall back to its configured E2B_DOMAIN/E2B_SANDBOX_URL.
 	//
 	// The sandbox ids published here are DNS-label safe (see sandboxid.go), so
-	// that host form resolves; the proxy in front of the sandboxes still has to
-	// route it, either on the host or on the E2b-Sandbox-Id / E2b-Sandbox-Port
-	// headers the SDK also sends.
+	// that host form is valid; wildcard DNS and a proxy must still route the host
+	// or the E2b-Sandbox-Id / E2b-Sandbox-Port headers the SDK sends.
 	Domain string
 	// EnvdVersion overrides DefaultEnvdVersion.
 	EnvdVersion string

--- a/pkg/e2bcompat/types.go
+++ b/pkg/e2bcompat/types.go
@@ -18,12 +18,10 @@ type NewSandbox struct {
 	TemplateID string `json:"templateID"`
 	// Timeout is the sandbox time-to-live in seconds (SDK default 15).
 	Timeout *int32 `json:"timeout,omitempty"`
-	// Metadata and EnvVars are echoed back on reads. They are recorded on the
-	// compat side only: the node-local claim path takes neither today.
+	// Metadata and EnvVars are accepted for SDK compatibility but discarded.
 	Metadata map[string]string `json:"metadata,omitempty"`
 	EnvVars  map[string]string `json:"envVars,omitempty"`
-	// AutoPause and Secure are accepted and reported back so an SDK that sets
-	// them does not fail; neither changes the claim.
+	// AutoPause and Secure are accepted for SDK compatibility but discarded.
 	AutoPause *bool `json:"autoPause,omitempty"`
 	Secure    *bool `json:"secure,omitempty"`
 	// AllowInternetAccess selects the warm pool's network lane: true picks the
@@ -84,7 +82,7 @@ type SandboxPauseRequest struct {
 }
 
 // ConnectSandbox is the POST /sandboxes/{id}/connect body — the SDK's resume.
-// timeout is required by the schema; TTL is only ever extended.
+// Timeout is required by the schema but does not change the node-owned lease.
 type ConnectSandbox struct {
 	Timeout int32 `json:"timeout"`
 }


### PR DESCRIPTION
## Summary

- align the E2B compatibility matrix with the implemented lifecycle, lease, request, metrics, routing, and admin surface
- distinguish implemented L2/L3 behavior from the remaining deployment and read-after-write work
- remove completed roadmap items and keep only current follow-ups

## Validation

- go generate ./...
- markdown local-link and code-fence audit
- ASL on host and Linux
- make lint fmt-check vet-tagged test-race
- make all apiserver-build