### PR TITLE
review: one scheme builder and one namespace helper for the bench harnesses

### DIFF
--- a/test/benchutil/benchutil.go
+++ b/test/benchutil/benchutil.go
@@ -9,14 +9,30 @@ import (
 	"slices"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	sandboxv1beta1 "github.com/cocoonstack/sandbox-operator/api/v1beta1"
 	extv1beta1 "github.com/cocoonstack/sandbox-operator/extensions/api/v1beta1"
 )
+
+func NewScheme(extra ...func(*runtime.Scheme) error) *runtime.Scheme {
+	s := runtime.NewScheme()
+	Must(sandboxv1beta1.AddToScheme(s))
+	Must(extv1beta1.AddToScheme(s))
+	for _, add := range extra {
+		Must(add(s))
+	}
+	return s
+}
+
+func EnsureNamespace(ctx context.Context, cl client.Client, name string, labels map[string]string) {
+	_ = cl.Create(ctx, &corev1.Namespace{Name: name, Labels: labels})
+}
 
 // Must exits the harness when err is non-nil.
 func Must(err error) {

--- a/test/e2ebench/main.go
+++ b/test/e2ebench/main.go
@@ -95,7 +95,7 @@ func main() {
 	prodBefore := podCount(ctx, *prodNS, *node)
 	fmt.Printf("[prod] baseline: %d desktop pods on %s\n", prodBefore, *node)
 
-	ensureNS(ctx)
+	benchutil.EnsureNamespace(ctx, cl, *ns, map[string]string{runLabel: runVal})
 	ensureTemplate(ctx)
 
 	fmt.Printf("[fill] creating pool %s replicas=%d on %s\n", poolName, *poolSize, *node)
@@ -143,10 +143,6 @@ func main() {
 	if !pass {
 		os.Exit(1)
 	}
-}
-
-func ensureNS(ctx context.Context) {
-	_ = cl.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: *ns, Labels: map[string]string{runLabel: runVal}}})
 }
 
 func ensureTemplate(ctx context.Context) {

--- a/test/l2bench/main.go
+++ b/test/l2bench/main.go
@@ -34,12 +34,10 @@ import (
 
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	sandboxv1beta1 "github.com/cocoonstack/sandbox-operator/api/v1beta1"
 	extv1beta1 "github.com/cocoonstack/sandbox-operator/extensions/api/v1beta1"
 	"github.com/cocoonstack/sandbox-operator/pkg/sandboxd"
 	"github.com/cocoonstack/sandbox-operator/pkg/scale"
@@ -115,13 +113,6 @@ func (s sliceInventory) LiveDeliveries(context.Context) ([]scale.Delivery, error
 	return []scale.Delivery(s), nil
 }
 
-func newScheme() *runtime.Scheme {
-	s := runtime.NewScheme()
-	benchutil.Must(sandboxv1beta1.AddToScheme(s))
-	benchutil.Must(extv1beta1.AddToScheme(s))
-	return s
-}
-
 func newClaim(name string) *extv1beta1.SandboxClaim {
 	return &extv1beta1.SandboxClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
@@ -166,7 +157,7 @@ func injectAndReconcileOrphans(ctx context.Context, fs *fakeSandboxd, orphans in
 		objs = append(objs, newClaim(fmt.Sprintf("orphan-%d", i)))
 	}
 	fc := fake.NewClientBuilder().
-		WithScheme(newScheme()).
+		WithScheme(benchutil.NewScheme()).
 		WithObjects(objs...).
 		WithStatusSubresource(&extv1beta1.SandboxClaim{}).
 		Build()

--- a/test/poolbench/main.go
+++ b/test/poolbench/main.go
@@ -91,7 +91,7 @@ func main() {
 		return
 	}
 
-	ensureNS(ctx)
+	benchutil.EnsureNamespace(ctx, cl, *ns, map[string]string{"cocoon-e2e-run": "g0129-pool"})
 	ensureTemplate(ctx)
 
 	fill := fillPool(ctx, *poolSize)
@@ -117,10 +117,6 @@ func main() {
 	b, _ := json.MarshalIndent(result, "", "  ")
 	_ = os.WriteFile(*out, b, 0o644)
 	fmt.Printf("wrote %s\n", *out)
-}
-
-func ensureNS(ctx context.Context) {
-	_ = cl.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: *ns, Labels: map[string]string{"cocoon-e2e-run": "g0129-pool"}}})
 }
 
 func ensureTemplate(ctx context.Context) {

--- a/test/scalebench/main.go
+++ b/test/scalebench/main.go
@@ -68,14 +68,6 @@ var (
 	maxPasses = flag.Int("max-passes", 8, "max reconcile passes per claim before giving up")
 )
 
-func newScheme() *runtime.Scheme {
-	s := runtime.NewScheme()
-	benchutil.Must(sandboxv1beta1.AddToScheme(s))
-	benchutil.Must(extv1beta1.AddToScheme(s))
-	benchutil.Must(corev1.AddToScheme(s))
-	return s
-}
-
 // warmSandbox builds one Ready, warm-pool-owned, adoptable Sandbox.
 func warmSandbox(idx int, poolHash, tmplHash string, poolUID types.UID) *sandboxv1beta1.Sandbox {
 	return &sandboxv1beta1.Sandbox{
@@ -121,7 +113,7 @@ func claim(idx int) *extv1beta1.SandboxClaim {
 // fixture returns a fake client seeded with N warm sandboxes + N claims, plus the
 // warm-pool queue populated with the N sandbox keys (as the event handler would).
 func fixture(n int) (ctrlclient.Client, *queue.SimpleSandboxQueue, []*extv1beta1.SandboxClaim, *runtime.Scheme) {
-	scheme := newScheme()
+	scheme := benchutil.NewScheme(corev1.AddToScheme)
 	poolHash := hash.Name(poolName)
 	tmplHash := ctrls.SandboxTemplateRefHash(tmplName)
 	poolUID := types.UID("pool-uid")

--- a/test/scalestress/main.go
+++ b/test/scalestress/main.go
@@ -97,7 +97,7 @@ func main() {
 		benchutil.Must(fmt.Errorf("refusing to run: prod baseline non-positive (%d)", prodBase))
 	}
 
-	ensureNS(ctx)
+	benchutil.EnsureNamespace(ctx, cl, *ns, map[string]string{runLabel: runVal})
 	ensureTemplate(ctx, hosts)
 
 	result := map[string]any{
@@ -228,10 +228,6 @@ func main() {
 	if abort != "" {
 		os.Exit(1)
 	}
-}
-
-func ensureNS(ctx context.Context) {
-	_ = cl.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: *ns, Labels: map[string]string{runLabel: runVal}}})
 }
 
 func ensureTemplate(ctx context.Context, hosts []string) {


### PR DESCRIPTION
## What

`test/benchutil` gains `NewScheme(extra ...func(*runtime.Scheme) error)` and `EnsureNamespace(ctx, cl, name, labels)`; `l2bench`/`scalebench` drop their private `newScheme`, `e2ebench`/`scalestress`/`poolbench` drop their private `ensureNS`. Net −11 lines, harness code only (every harness is build-tagged; nothing under `pkg/`, `controllers/` or `internal/` changes).

## Evidence

- `GOWORK=off go build -tags <tag> ./test/<tag>/` for l2bench, scalebench, e2ebench, scalestress, poolbench: all build.
- `make lint` GOOS=darwin and GOOS=linux: 0 issues; `make fmt-check`: clean; `asl ./...` both GOOS: clean.
- `go test -race ./test/benchutil/ ./internal/...`: ok.
- Comment lines: +0 −0.