### PR TITLE
review: settle the asl forwarder advisories

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1177,7 +1177,7 @@ func (r *SandboxClaimReconciler) sandboxFromStatus(ctx context.Context, claim *e
 // still owned by the warm pool means an adoption is half-finished, which this
 // completes.
 func (r *SandboxClaimReconciler) sandboxFromClaimMetadata(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*v1beta1.Sandbox, error) {
-	sbName := assignedSandboxName(claim)
+	sbName := claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation]
 	if sbName == "" {
 		return nil, nil
 	}
@@ -1896,11 +1896,6 @@ func validateVolumeClaimTemplates(vcts []v1beta1.PersistentVolumeClaimTemplate) 
 		names[vct.Name] = struct{}{}
 	}
 	return nil
-}
-
-// assignedSandboxName reads the assigned-sandbox annotation.
-func assignedSandboxName(claim *extensionsv1beta1.SandboxClaim) string {
-	return claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation]
 }
 
 // warmPoolRefIndexer indexes SandboxClaims by spec.warmPoolRef.name.

--- a/internal/lifecycle/expiry.go
+++ b/internal/lifecycle/expiry.go
@@ -42,11 +42,6 @@ func TimeLeft(now time.Time, shutdownTime *metav1.Time, ttlSecondsAfterFinished 
 	return false, expireAt.Sub(now)
 }
 
-// needsCleanup reports whether ttl-after-finished cleanup applies.
-func needsCleanup(ttlSecondsAfterFinished *int32, finishedCondition *metav1.Condition) bool {
-	return ttlSecondsAfterFinished != nil && finishedCondition != nil
-}
-
 // finishedTime returns the finish timestamp encoded in the terminal condition.
 func finishedTime(finishedCondition *metav1.Condition) *time.Time {
 	if finishedCondition == nil || finishedCondition.LastTransitionTime.IsZero() {
@@ -64,7 +59,7 @@ func expireAtFor(shutdownTime *metav1.Time, ttlSecondsAfterFinished *int32, fini
 		expireAt = &shutdownAt
 	}
 
-	if !needsCleanup(ttlSecondsAfterFinished, finishedCondition) {
+	if ttlSecondsAfterFinished == nil || finishedCondition == nil {
 		return expireAt
 	}
 

--- a/pkg/e2bcompat/http.go
+++ b/pkg/e2bcompat/http.go
@@ -3,8 +3,6 @@ package e2bcompat
 import (
 	"encoding/json"
 	"net/http"
-
-	"k8s.io/apiserver/pkg/storage/names"
 )
 
 const (
@@ -16,13 +14,6 @@ const (
 	// sandboxes` and in node inventory.
 	namePrefix = "e2b-"
 )
-
-// generateName returns a fresh Kubernetes-safe name for a compat claim. e2b
-// clients do not name their sandboxes; the identity a caller sees back is the
-// node-assigned claim id, not this name.
-func generateName() string {
-	return names.SimpleNameGenerator.GenerateName(namePrefix)
-}
 
 // writeJSON writes v as the response body with the given status.
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/pkg/e2bcompat/server.go
+++ b/pkg/e2bcompat/server.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/go-logr/logr"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/storage/names"
 
 	sandboxv1beta1 "github.com/cocoonstack/sandbox-operator/api/v1beta1"
 	"github.com/cocoonstack/sandbox-operator/pkg/scale"
@@ -196,7 +197,7 @@ func (s *Server) createSandbox(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	name := generateName()
+	name := names.SimpleNameGenerator.GenerateName(namePrefix)
 	pool := scale.PoolKey{
 		Template: req.TemplateID,
 		Net:      netFor(req.AllowInternetAccess),


### PR DESCRIPTION
## Why

`asl` now carries a `forwarder` advisory: an unexported one-statement func with exactly one call site. Four fired here; this settles them.

## What

- `assignedSandboxName`, `needsCleanup`, `generateName` inlined at their single call sites (net -18 lines); `pkg/e2bcompat/http.go` drops the `names` import that moves to `server.go`.
- `putJSON` stays as the PUT member of the get/post/put family over `sendJSON`; recorded as kept in the hygiene ledger.

No behaviour change; no comment added.

## Evidence

`GOWORK=off make fmt-check` rc=0; `GOWORK=off make lint` rc=0 with two `0 issues` lines (linux + darwin); `asl ./...` on both GOOS reports only the kept advisory; `GOWORK=off go test -race -count=1 ./...` rc=0, no FAIL lines.